### PR TITLE
Fixes on the grammar helper

### DIFF
--- a/grammar/grammar-check-spelling
+++ b/grammar/grammar-check-spelling
@@ -32,7 +32,7 @@ find ../lynis/include -type f -exec strings {} \; | tr ' ' '\n' >> "${DATAFILE}"
 # sort  sort and only store unique words
 
 
-cat ${DATAFILE} | \
+cat "${DATAFILE}" | \
     tr '=' ' ' | \
     tr '/' ' ' | \
     grep -E "^[a-zA-Z]{4,}" | \
@@ -45,9 +45,9 @@ cat ${DATAFILE} | \
     awk '{if ($2 <= 1) { print $1 }}' | \
     grep -E "^[a-zA-Z]{4,}" | \
     tr '[:upper:]' '[:lower:]' | \
-    sort --unique > ${DATAFILE_SORTED}
+    sort --unique > "${DATAFILE_SORTED}"
 
-aspell --lang=en --ignore-case --personal=./grammar/words-to-ignore.en.pws check ${DATAFILE_SORTED}
+aspell --lang=en --ignore-case --personal=./grammar/words-to-ignore.en.pws check "${DATAFILE_SORTED}"
 
-if [ -f ${DATAFILE} ]; then rm ${DATAFILE}; fi
-if [ -f ${DATAFILE_SORTED} ]; then rm ${DATAFILE_SORTED}; fi
+if [ -f "${DATAFILE}" ]; then rm "${DATAFILE}"; fi
+if [ -f "${DATAFILE_SORTED}" ]; then rm "${DATAFILE_SORTED}"; fi

--- a/grammar/grammar-check-spelling
+++ b/grammar/grammar-check-spelling
@@ -13,8 +13,8 @@ DATAFILE=$(mktemp /tmp/lynis-strings.XXXXXXXXXX)
 DATAFILE_SORTED=$(mktemp /tmp/lynis-strings-sorted.XXXXXXXXXX)
 
 echo "Temporary file: ${DATAFILE}"
-strings /data/development/lynis/lynis > ${DATAFILE}
-find /data/development/lynis/include -type f -exec strings {} \; | tr ' ' '\n' >> ${DATAFILE}
+strings ../lynis/lynis > "${DATAFILE}"
+find ../lynis/include -type f -exec strings {} \; | tr ' ' '\n' >> "${DATAFILE}"
 
 
 # tr    delete quotes (disabled) #    tr -d "'" | \

--- a/grammar/grammar-check-spelling
+++ b/grammar/grammar-check-spelling
@@ -3,7 +3,11 @@
 set -o nounset
 #set -o pipefail
 
-if ! command -v aspell > /dev/null; then SDKExitFatal "Missing aspell utility"; fi
+if ! command -v aspell > /dev/null; then
+    SDKExitFatal "Missing aspell utility"
+elif ! aspell dump dicts | grep -qw "en$" > /dev/null ; then
+    SDKExitFatal "Missing aspell English dictionary (aspell-en)"
+fi
 
 DATAFILE=$(mktemp /tmp/lynis-strings.XXXXXXXXXX)
 DATAFILE_SORTED=$(mktemp /tmp/lynis-strings-sorted.XXXXXXXXXX)
@@ -47,5 +51,3 @@ aspell --lang=en --ignore-case --personal=./grammar/words-to-ignore.en.pws check
 
 if [ -f ${DATAFILE} ]; then rm ${DATAFILE}; fi
 if [ -f ${DATAFILE_SORTED} ]; then rm ${DATAFILE_SORTED}; fi
-
-


### PR DESCRIPTION
This allows the use of `lynis-devkit run spelling-check` with improved checks